### PR TITLE
projects: support libplacebo

### DIFF
--- a/config/default.conf
+++ b/config/default.conf
@@ -141,6 +141,10 @@ config_angleheaders_source="./source/angle-headers"
 config_angleheaders_git="https://github.com/google/angle.git"
 config_angleheaders_update=head
 
+config_libplacebo_source="./source/libplacebo"
+config_libplacebo_git="https://github.com/haasn/libplacebo"
+config_libplacebo_update="head"
+
 config_mpv_source="./source/mpv"
 config_mpv_git="https://github.com/mpv-player/mpv.git"
 config_mpv_update="head"

--- a/debian/rules
+++ b/debian/rules
@@ -4,10 +4,14 @@
 # You can either set DEB_BUILD_OPTIONS=parallel=<num-procs> in your build environment
 # or provide the -j<numprocs> option to debuild or dpkg-buildpackage, which
 # amounts to the same thing.
-ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-	NUMJOBS = $(patsubst parallel=%,%,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
-# use MFLAGS, rather than MAKEFLAGS as the latter is used by make internally
+parallel=$(filter parallel=%,$(DEB_BUILD_OPTIONS))
+ifeq (,$(parallel))
+	NINJAFLAGS += -j1
+else
+	NUMJOBS = $(patsubst parallel=%,%,$(parallel))
+    # use MFLAGS, rather than MAKEFLAGS as the latter is used by make internally
 	MFLAGS += -j$(NUMJOBS)
+	NINJAFLAGS += -j$(NUMJOBS)
 	WAFFLAGS += -j$(NUMJOBS)
 endif
 
@@ -34,7 +38,7 @@ shaderc_config:
 	./build --mode=config shaderc
 
 shaderc_build: shaderc_config
-	./build --mode=build shaderc
+	./build --mode=build shaderc -- $(NINJAFLAGS)
 
 crossc_config:
 	./build --mode=config crossc
@@ -59,6 +63,12 @@ libaom_config:
 
 libaom_build: libaom_config
 	./build --mode=build libaom -- $(MFLAGS)
+
+libplacebo_config: $(filter shaderc_build,$(projects_build))
+	./build --mode=config libplacebo
+
+libplacebo_build: libplacebo_config
+	./build --mode=build libplacebo -- $(NINJAFLAGS)
 
 # depend on libass_build in case the user specified --enable-libass in ffmpeg_options
 ffmpeg_config: $(filter libass_build libaom_build,$(projects_build))

--- a/scripts/libplacebo-build
+++ b/scripts/libplacebo-build
@@ -1,0 +1,5 @@
+#! /bin/sh
+
+set -ex
+
+exec ninja -C "$config_libplacebo_source/build" install "$@"

--- a/scripts/libplacebo-clean
+++ b/scripts/libplacebo-clean
@@ -1,0 +1,7 @@
+#! /bin/sh
+
+set -e
+
+[ -d "$config_libplacebo_source/build" ] || exit 0
+
+cd "$config_libplacebo_source" && exec rm -rf build

--- a/scripts/libplacebo-config
+++ b/scripts/libplacebo-config
@@ -1,0 +1,29 @@
+#! /bin/sh
+
+set -ex
+
+OPTIONS=
+
+case $config_build_pic in yes)
+	OPTIONS="$OPTIONS --b_staticpic=true"
+;; no)
+	OPTIONS="$OPTIONS --b_staticpic=false"
+esac
+
+case $config_build_host in ?*)
+	case $* in *cross-file*) ;; *)
+		cat >&2 <<EOT
+It seems you are trying to cross-compile libplacebo.
+This is currently not implemented automatically because meson requires a
+target host specific configuration file for that.
+
+Please use an option --cross-file=/path/to/meson-cross.txt to enable
+cross-compilation.
+
+See https://mesonbuild.com/Cross-compilation.html for details.
+EOT
+		exit 2
+	esac
+esac
+
+exec meson setup --buildtype=release --default-library=static --libdir=lib --prefix="$config_local_prefix" $OPTIONS "$@" "$config_libplacebo_source/build" "$config_libplacebo_source"


### PR DESCRIPTION
Required for Vulkan support in recent versions of mpv.
    
This also introduces a $(NINJA) variable in the debian/rules makefile to properly handle parallel builds (with the correct number of parallel processes) for libplacebo and shaderc.