### PR TITLE
libplacebo: use -Db_staticpic instead of --b_staticpic

### DIFF
--- a/scripts/libplacebo-config
+++ b/scripts/libplacebo-config
@@ -5,9 +5,9 @@ set -ex
 OPTIONS=
 
 case $config_build_pic in yes)
-	OPTIONS="$OPTIONS --b_staticpic=true"
+	OPTIONS="$OPTIONS -Db_staticpic=true"
 ;; no)
-	OPTIONS="$OPTIONS --b_staticpic=false"
+	OPTIONS="$OPTIONS -Db_staticpic=false"
 esac
 
 case $config_build_host in ?*)


### PR DESCRIPTION
The documentation states that these can be used interchangeably, but
building it just now it gave me the following error:

`meson: error: unrecognized arguments: --b_staticpic=false`

So apparently the documentation is wrong or perhaps the `--b_staticpic`
syntax only works on very new versions of meson.

Probably caused by me not testing the final version of of PR#2 properly.