### PR TITLE
mpv: remove --enable-zsh-comp from the Debian build rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -102,8 +102,7 @@ override_dh_auto_configure: $(filter-out mpv_build,$(projects_build))
 		--enable-openal \
 		--enable-dvdnav \
 		--enable-cdda \
-		--enable-libsmbclient \
-		--enable-zsh-comp
+		--enable-libsmbclient
 
 override_dh_auto_build:
 	./build --mode=build mpv -- $(WAFLAGS)


### PR DESCRIPTION
Option seems to be gone.