### PR TITLE
Remove --enable-libwavpack from ffmpeg_config

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -87,7 +87,6 @@ ffmpeg_config: $(filter libass_build libaom_build,$(projects_build))
 		--enable-libtwolame \
 		--enable-libvorbis \
 		--enable-libvpx \
-		--enable-libwavpack \
 		--enable-ladspa \
 		--enable-libbs2b \
 		--enable-gpl --enable-libxvid --enable-libx264 \


### PR DESCRIPTION
This command line option is no longer supported by ffmpeg, since
commit 45070eec4c089b06947f07e25cdb1bc8b2102553 (2020-10-02).