### PR TITLE
Use python3 for /usr/bin/python if python2 is no longer available

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -66,8 +66,8 @@ Build-Depends:
  libxvidcore-dev,
  ninja-build,
  pkg-config,
- python,
- python-docutils,
+ python | python-is-python3,
+ python-docutils | python3-docutils,
  x11proto-core-dev,
  yasm,
  zlib1g-dev


### PR DESCRIPTION
As distros start to remove python2 from their repositories, we need to make
sure waf can still run python from its shebang.

The order of the alternatives is chosen such that distros that have the
python3-docutils package but not python-is-python3 will install a
compatible combination (namely, python and python-docutils).