### PR TITLE
Use the correct destination for zsh completion files on Debian

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -97,7 +97,10 @@ ffmpeg_build: ffmpeg_config
 
 # put the config in the right place and drop the local/ since it's package managed now
 override_dh_auto_configure: $(filter-out mpv_build,$(projects_build))
-	./build --mode=config mpv -- --prefix=/usr --confdir=/etc/mpv \
+	./build --mode=config mpv -- \
+		--prefix=/usr \
+		--confdir=/etc/mpv \
+		--zshdir=/usr/share/zsh/vendor-completions \
 		--enable-openal \
 		--enable-dvdnav \
 		--enable-cdda


### PR DESCRIPTION
Debian zsh reads completion scripts from `/usr/share/zsh/vendor-completions`. Since the default is `/usr/share/zsh/site-functions` (which is suitable for Fedora and the likes, apparently) we need to specify this explicitly.

Thanks to sumiregawa syo for their bugreport.