### PR TITLE
Add a more recent version number to the generated shaderc.pc

### DIFF
--- a/scripts/shaderc-build
+++ b/scripts/shaderc-build
@@ -16,7 +16,7 @@ cat <<- PCFILE > "$pcfile"
 
 	Name: libshaderc
 	Description: static libshaderc in mpv-build
-	Version: 0.1
+	Version: 2019.1
 	Libs: -L\${libdir} -lshaderc_combined -lstdc++
 	Libs.private:
 	Cflags: -I\${includedir}


### PR DESCRIPTION
Fixes linking errors in libplacebo.
    
These days shaderc ships its own .pc files, though without -lstdc++. While we can't use those directly we could conceivably use those as a base for our own generated shaderc.pc.
