### PR TITLE
Fix debian dependencies

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -16,6 +16,7 @@ Build-Depends:
  libbs2b-dev,
  libcaca-dev,
  libcdio-paranoia-dev,
+ libdrm-dev,
  libdvdnav-dev,
  libegl1-mesa-dev,
  libfontconfig-dev,
@@ -66,8 +67,8 @@ Build-Depends:
  libxvidcore-dev,
  ninja-build,
  pkg-config,
- python | python-is-python3,
- python-docutils | python3-docutils,
+ python3,
+ python3-docutils,
  x11proto-core-dev,
  yasm,
  zlib1g-dev


### PR DESCRIPTION
Now that mpv uses python3 in its waf shebang, we can and must
standardise on python3 only, and drop the python2 stuff.

We also need an explicit dependency on libdrm-dev because it's not pulled
in implicitly anymore.
