### PR TITLE
debian: disable LTO

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -1,5 +1,7 @@
 #! /usr/bin/make -f
 
+export DEB_BUILD_MAINT_OPTIONS := hardening=+all optimize=-lto
+
 # To enable parallel building:
 # You can either set DEB_BUILD_OPTIONS=parallel=<num-procs> in your build environment
 # or provide the -j<numprocs> option to debuild or dpkg-buildpackage, which


### PR DESCRIPTION
Newer versions of Ubuntu (and future versions of Debian) enable LTO by default for package builds. This is apparently incompatible with how we compile mpv using static builds of ffmpeg and libass.

Fixes https://github.com/mpv-player/mpv-build/issues/158

Further reading:
 - https://wiki.ubuntu.com/ToolChain/LTO
 - https://wiki.debian.org/ToolChain/LTO

(I tried to --enable-lto in ffmpeg but that caused assembler errors in every arch but amd64.)

Also re-enables full hardening: the compile issues with that seem to have gone away.