### PR TITLE
debian: do not parallelize debian/rules

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -15,6 +15,9 @@ else
 	WAFFLAGS += -j$(NUMJOBS)
 endif
 
+# But don't parallelize this makefile itself:
+.NOTPARALLEL:
+
 # make .PHONY all the targets that have name collisions with the scripts
 # see http://www.debian.org/doc/manuals/maint-guide/dreq.en.html#rules
 .PHONY: clean build install


### PR DESCRIPTION
Having the rules from debian/rules executing in parallel causes the
configured number of processes to be exceeded because several build
tools (like ninja) spawn a number of processes in turn.